### PR TITLE
fix display of update Second_ultrasound tab

### DIFF
--- a/src/components/Modals/PatientDetailModals/index.tsx
+++ b/src/components/Modals/PatientDetailModals/index.tsx
@@ -1297,8 +1297,14 @@ export const ModalInputSecondUltrasoundTestResult = ({
     },
   };
   // Hide or show nose_bone_length
-  const [isHasNoseBone, setIsHasNoseBone] = useState(false);
-
+  var [isHasNoseBone, setIsHasNoseBone] = useState(false);
+  if (editingData){
+    if (editingData.nose_bone == true){
+      var [isHasNoseBone, setIsHasNoseBone] = useState(true);
+    } else if (editingData.nose_bone == false){
+      var [isHasNoseBone, setIsHasNoseBone] = useState(false);
+    }
+  }
   return (
     <BaseModal
       title="Siêu âm kỳ 2"

--- a/src/components/Modals/PatientDetailModals/index.tsx
+++ b/src/components/Modals/PatientDetailModals/index.tsx
@@ -1297,14 +1297,7 @@ export const ModalInputSecondUltrasoundTestResult = ({
     },
   };
   // Hide or show nose_bone_length
-  var [isHasNoseBone, setIsHasNoseBone] = useState(false);
-  if (editingData){
-    if (editingData.nose_bone == true){
-      var [isHasNoseBone, setIsHasNoseBone] = useState(true);
-    } else if (editingData.nose_bone == false){
-      var [isHasNoseBone, setIsHasNoseBone] = useState(false);
-    }
-  }
+  const [isHasNoseBone, setIsHasNoseBone] = useState(editingData?.nose_bone);
   return (
     <BaseModal
       title="Siêu âm kỳ 2"


### PR DESCRIPTION
<h1> Fix UI of update Second Ultrasound test</h1>

<h3>When the doctor presses edit, the old UI does not show the length of the nose bone while the data returned has the nose bone.</h3>

![image](https://user-images.githubusercontent.com/91403009/201863608-35b58864-3e89-4411-ad24-6b3cd5df9219.png)

<h3>--> UPDATE: When the doctor presses edit, the length of the nose bone is displayed while the data returned has the nasal bone.</h3>

![image](https://user-images.githubusercontent.com/91403009/201863700-28c0e2ab-34ab-4322-8042-9fce25300965.png)
